### PR TITLE
Switch share script to hard code url

### DIFF
--- a/helpers/share.sh
+++ b/helpers/share.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 # This script runs when you click the Share button!
 
-readarray -t lines < <(gh codespace ports --codespace=${CODESPACE_NAME})
-for i in "${lines[@]}"
-do
-    read -ra entries <<<"$i"
-    code=$(curl -s -o /dev/null -w "%{http_code}" ${entries[-1]})
-    if [[ ${code} -lt 400 ]] ; then
-        printf "\n📣 Share your website preview by copying this URL: ${entries[-1]}\n\n"
-        break
-    fi
-done
+gh codespace ports visibility 8080:public -c $CODESPACE_NAME 
+printf "\n📣 Share your website preview by copying this URL: https://${CODESPACE_NAME}-8080.app.github.dev\n\n"


### PR DESCRIPTION
Something appears to have changed in the way github cli handles the `gh codespace ports` calls so switching the **Share** button functionality to hard code the share URL based on the assumed port number instead!